### PR TITLE
Add missing path parameter to GetIarEwArmVersion.yaml

### DIFF
--- a/GetIarEwArmVersion.yaml
+++ b/GetIarEwArmVersion.yaml
@@ -10,6 +10,9 @@
 # Outputs:
 # - version     # Version of the IAR compiler
 
+parameters:
+  path: 'C:\Program Files\IAR Systems\Embedded Workbench 9.2'
+
 
 steps:
 


### PR DESCRIPTION
This PR fixes a missing path parameter to the GetIarEwArmVersion.yaml workflow.