### PR TITLE
Add the github purl for the nuget client

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "demaconsulting.spdxtool": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "commands": [
         "spdx-tool"
       ]

--- a/AddNugetPackage.yaml
+++ b/AddNugetPackage.yaml
@@ -37,4 +37,5 @@ steps:
       originator: 'Organization: Microsoft Corporation'
       homepage: https://www.nuget.org
       summary: The NuGet client tools provide the ability to produce and consume packages.
+      purl: pkg:github/NuGet/NuGet.Client@${{ version }}
     relationships: [ ]

--- a/GetVsTestVersion.yaml
+++ b/GetVsTestVersion.yaml
@@ -21,7 +21,7 @@ steps:
 - command: query
   inputs:
     output: version
-    pattern: 'Version\s+(?<value>17\.[0-9\.]+)'
+    pattern: '[Vv]ersion\s+(?<value>[0-9\.]+)'
     program: '${{ vstest }}'
     arguments:
-    - '--version'
+    - '-?'

--- a/test/DemaConsulting.SpdxWorkflows.Tests/AddNugetPackage.cs
+++ b/test/DemaConsulting.SpdxWorkflows.Tests/AddNugetPackage.cs
@@ -25,5 +25,11 @@ public class AddNugetPackage : AddPackageTest
         Assert.AreEqual("Organization: Microsoft Corporation", package.Originator);
         Assert.AreEqual("https://www.nuget.org", package.HomePage);
         Assert.AreEqual("The NuGet client tools provide the ability to produce and consume packages.", package.Summary);
+
+        // Verify the PURL
+        Assert.AreEqual(1, package.ExternalReferences.Length);
+        Assert.AreEqual(SpdxModel.SpdxReferenceCategory.PackageManager, package.ExternalReferences[0].Category);
+        Assert.AreEqual("purl", package.ExternalReferences[0].Type);
+        Assert.AreEqual("pkg:github/NuGet/NuGet.Client@6.9.1.3", package.ExternalReferences[0].Locator);
     }
 }

--- a/test/DemaConsulting.SpdxWorkflows.Tests/DemaConsulting.SpdxWorkflows.Tests.csproj
+++ b/test/DemaConsulting.SpdxWorkflows.Tests/DemaConsulting.SpdxWorkflows.Tests.csproj
@@ -15,9 +15,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="DemaConsulting.SpdxModel" Version="1.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DemaConsulting.SpdxWorkflows.Tests/Runner.cs
+++ b/test/DemaConsulting.SpdxWorkflows.Tests/Runner.cs
@@ -34,11 +34,13 @@ internal static class Runner
         var process = Process.Start(startInfo) ??
                       throw new InvalidOperationException("Failed to start process");
 
+        // Capture the output
+        output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+
         // Wait for the process to exit
         process.WaitForExit();
 
-        // Save the output and return the exit code
-        output = process.StandardOutput.ReadToEnd();
+        // Return the exit code
         return process.ExitCode;
     }
 }


### PR DESCRIPTION
This PR closes issue #11 by adding a purl for the NuGet client referring to the github repository.