### PR TITLE
Fix nuget version query.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "demaconsulting.spdxtool": {
-      "version": "2.1.1",
+      "version": "2.2.0",
       "commands": [
         "spdx-tool"
       ]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: write
       packages: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -37,7 +37,7 @@ jobs:
         --filter "TestCategory=AnyOS|TestCategory=Windows"
 
     - name: Run Linux Tests
-      if: ${{ matrix.os =='ubuntu-latest' }}
+      if: ${{ matrix.os =='ubuntu-22.04' }}
       run: >
         dotnet test test/DemaConsulting.SpdxWorkflows.Tests
         --no-build

--- a/GetNugetVersion.yaml
+++ b/GetNugetVersion.yaml
@@ -17,5 +17,3 @@ steps:
     output: version
     pattern: '^NuGet Version: (?<value>.*)$'
     program: 'nuget'
-    arguments:
-    - help


### PR DESCRIPTION
This PR fixes querying nuget version by:
* Locking to ubuntu-22.04 as ubuntu-24.x and later don't support nuget.exe (no mono runtime)
* Querying nuget version by running with no arguments and gets the banner splash