### PR TITLE
Cleanup nuget push to use correct path.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,6 @@ jobs:
         run: >
           dotnet
           nuget push
-          artifacts/src/DemaConsulting.SpdxWorkflows/bin/Release/*.nupkg
+          artifacts/DemaConsulting.SpdxWorkflows.*.nupkg
           --source "https://api.nuget.org/v3/index.json"
           --api-key "${{ secrets.DEMACONSULTINGNUGETKEY }}"


### PR DESCRIPTION
This PR cleans up the publish step for the new nuget package.